### PR TITLE
add firefox fallback for innerText

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "contents",
   "title": "Contents",
   "description": "Automatically generate table of contents for a given area of content.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "devDependencies": {
     "karma": "^0.12.22",

--- a/src/contents.js
+++ b/src/contents.js
@@ -292,7 +292,7 @@ contents.level = function (element) {
 contents.link = function (guide, article) {
     var guideLink = document.createElement('a'),
         articleLink = document.createElement('a'),
-        articleName = article.innerText,
+        articleName = article.innerText || article.textContent,
         articleId = article.id || contents.id(articleName);
 
     article.id = articleId;


### PR DESCRIPTION
Firefox doesn't support `innerText` (http://www.quirksmode.org/dom/html/#t01) and this causes a js error.  Adding a fallback to `textContent` seems to make everything work as expected.
