### PR TITLE
Removed obsolete field

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,6 @@
   "dependencies": {
     "jquery": ">=1"
   },
-  "version": "3.0.4",
   "name": "contents",
   "description": "Table of contents generator.",
   "keywords": [


### PR DESCRIPTION
Bower now uses git tags for versioning (https://github.com/bower/bower.json-spec/commit/a325da3).  Be sure to keep the tag up to date (current latest tag is 3.0.3, but package.json lists it as 3.0.4).